### PR TITLE
Add cfn templates for dev env resources for import/export tool

### DIFF
--- a/codebuild-ecr.template.yaml
+++ b/codebuild-ecr.template.yaml
@@ -1,0 +1,79 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CodeBuild projects and ECR repositories for ITS CodeHub.
+
+Parameters:
+  CodeBuildRoleArn:
+    Type: String
+
+Resources:
+  ################################
+  ### Import/Export Tool Resources
+
+  # ECR Repositories
+  ImportExportECRDev:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: import-export-dev
+
+  # CodeBuild Projects
+  ImportExportCodeBuildGeneric:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for testing buildability of all commits.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: VARIABLE_1
+            Type: PLAINTEXT
+            Value: "variable_1"
+      Name: import-export-generic
+      ServiceRole: !Ref CodeBuildRoleArn
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-jpo-codehub/codehub-import-export.git # TODO validate this
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/(master|development)$"
+              ExcludeMatchedPattern: True
+        Webhook: True
+
+  ImportExportCodeBuildDev:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for deploying the Import/Export to dev.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: VARIABLE_1
+            Type: PLAINTEXT
+            Value: "variable_1"
+      Name: import-export-dev
+      ServiceRole: !Ref CodeBuildRoleArn
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-jpo-codehub/codehub-import-export.git # TODO validate this
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/development$"
+              ExcludeMatchedPattern: False
+        Webhook: True

--- a/ecs.template.yaml
+++ b/ecs.template.yaml
@@ -1,0 +1,113 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: ECS services used by ITS CodeHub.
+Parameters:
+  TaskRoleArn:
+    Type: String
+  ExecutionRoleArn:
+    Type: String
+  ImportExportPort:
+    Type: Number
+    Default: 80
+  VPCIdDev:
+    Type: "AWS::EC2::VPC::Id"
+  LBSecurityGroupDev:
+    Type: "AWS::EC2::SecurityGroup::Id"
+  ServiceSecurityGroupDev:
+    Type: "AWS::EC2::SecurityGroup::Id"
+  SubnetADev:
+    Type: "AWS::EC2::Subnet::Id"
+  SubnetBDev:
+    Type: "AWS::EC2::Subnet::Id"
+
+Resources:
+  ################################
+  ### Import/Export Tool Resources
+
+  ImportExportServiceDev:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - ImportExportListenerDev
+    Properties:
+      ServiceName: import-export-service-dev
+      Cluster: codehub-cluster-dev
+      TaskDefinition: !Ref ImportExportTaskDefDev
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - !Ref SubnetADev
+            - !Ref SubnetBDev
+          SecurityGroups:
+            - !Ref ServiceSecurityGroupDev
+      LoadBalancers:
+        - ContainerName: import-export-dev-container
+          ContainerPort: !Ref ImportExportPort
+          TargetGroupArn: !Ref ImportExportTargetGroupDev
+
+  ImportExportTargetGroupDev:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: import-export-dev-tg
+      Port: !Ref ImportExportPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: !Ref VPCIdDev
+
+  ImportExportListenerDev:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref ImportExportTargetGroupDev
+          Type: forward
+      LoadBalancerArn: !Ref ImportExportLoadBalancerDev
+      Port: !Ref ImportExportPort
+      Protocol: HTTP
+
+  ImportExportLoadBalancerDev:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: import-export-dev-lb
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref LBSecurityGroupDev
+      Subnets:
+        - !Ref SubnetADev
+        - !Ref SubnetBDev
+
+  ImportExportTaskDefDev:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - ImportExportLogGroupDev
+    Properties:
+      Family: import-export-dev-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: !Ref ExecutionRoleArn
+      TaskRoleArn: !Ref TaskRoleArn
+      ContainerDefinitions:
+        - Name: import-export-dev-container
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.region.amazonaws.com/import-export-dev:latest"
+          PortMappings:
+            - ContainerPort: !Ref ImportExportPort
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref ImportExportLogGroupDev
+              awslogs-stream-prefix: ecs
+
+  ImportExportLogGroupDev:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/import-export-dev-taskdef"

--- a/ecs.template.yaml
+++ b/ecs.template.yaml
@@ -100,6 +100,9 @@ Resources:
           Image: !Sub "${AWS::AccountId}.dkr.ecr.region.amazonaws.com/import-export-dev:latest"
           PortMappings:
             - ContainerPort: !Ref ImportExportPort
+          Environment:
+            - Name: VARIABLE_2
+              Value: "variable_2"
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
### Description

Adds the ECS Service (and all dependent resources), ECR repo, and CodeBuild jobs for the dev environment implementation of the import/export tool.

### Requirements
- URL of the GitHub repo
- CodeBuild environment variables for generic builds
- CodeBuild environment variables for development deployment builds
- Fargate container (runtime) environment variables

### Changes
- Add ECS cloudformation template for import/export tool for dev env
- Add CodeBuild/ECR cfn template for import/export tool for dev env
